### PR TITLE
[DO NOT MERGE] draft for findImportMeta

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -145,7 +145,7 @@ type ImportMetaChainItem = ImportMetaCallChain | ImportMetaMemberChain;
  * Represents an import.meta expression in an ECMAScript module.
  * Contains position information and parsed chain information for the import.meta occurrence.
  */
-export interface ImportMetaMatch {
+export interface ImportMetaExpression {
   /**
    * Indicates that this is an import.meta expression.
    */
@@ -409,9 +409,9 @@ export function findTypeImports(code: string): TypeImport[] {
 /**
  * Finds all import.meta expressions within the given code string.
  * @param {string} code - The source code to search for import.meta expressions.
- * @returns {ImportMetaMatch[]} An array of {@link ImportMetaMatch} objects representing each import.meta expression found.
+ * @returns {ImportMetaExpression[]} An array of {@link ImportMetaExpression} objects representing each import.meta expression found.
  */
-export function findImportMeta(code: string): ImportMetaMatch[] {
+export function findImportMeta(code: string): ImportMetaExpression[] {
   const matches = matchAll(IMPORT_META_RE, code, { type: "meta" });
   const filtered = _filterStatement(_tryGetLocations(code, "import"), matches);
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -402,29 +402,10 @@ export function findImportMeta(code: string): ImportMetaMatch[] {
   const matches = matchAll(IMPORT_META_RE, code, { type: "meta" });
   const filtered = _filterStatement(_tryGetLocations(code, "import"), matches);
 
-  // Parse each match to extract chain information and adjust match boundaries
+  // Parse each match to extract chain information
   return filtered.map((match) => {
     const originalCode = match.code;
     const chain = _parseImportMetaChain(originalCode);
-
-    // Find where the first method call ends using regex (with optional whitespace)
-    const firstMethodPattern =
-      /^import\.meta(?:\s*\.\s*\w+)*?(\s*\.\s*\w+\s*\([^)]*(?:\([^)]*\)[^)]*)*\))/;
-    const methodMatch = originalCode.match(firstMethodPattern);
-
-    if (methodMatch) {
-      // Cut the code at the end of the first method call
-      const methodEndPos = methodMatch[0].length;
-      const adjustedCode = originalCode.slice(0, methodEndPos);
-      const adjustedEnd = match.start + methodEndPos;
-
-      return {
-        ...match,
-        code: adjustedCode,
-        end: adjustedEnd,
-        chain,
-      };
-    }
 
     return {
       ...match,
@@ -829,7 +810,6 @@ function _parseImportMetaChain(code: string): ImportMetaChainItem[] {
         type: "call",
         args: args.length > 0 ? args : [],
       });
-      break;
     } else {
       chain.push({
         name,

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -323,7 +323,7 @@ export const DYNAMIC_IMPORT_RE =
  * @example `import.meta.url`, `import.meta.env`, `import.meta.resolve()`
  */
 export const IMPORT_META_RE =
-  /\bimport\.meta(?:(?:\s*\.\s*\w+(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+)/gm;
+  /\bimport\.meta(?<chain>(?:(?:\s*\.\s*\w+(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+))/gm;
 
 const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+(?:[\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
@@ -404,8 +404,7 @@ export function findImportMeta(code: string): ImportMetaMatch[] {
 
   // Parse each match to extract chain information
   return filtered.map((match) => {
-    const originalCode = match.code;
-    const chain = _parseImportMetaChain(originalCode);
+    const chain = _parseImportMetaChain(match.chain || "");
 
     return {
       ...match,
@@ -784,17 +783,14 @@ function _getLocations(code: string, label: string) {
   return locations;
 }
 
-function _parseImportMetaChain(code: string): ImportMetaChainItem[] {
+function _parseImportMetaChain(chainString: string): ImportMetaChainItem[] {
   const chain: ImportMetaChainItem[] = [];
-
-  // Remove "import.meta" prefix and parse the rest
-  const remaining = code.replace(/^import\.meta/, "");
 
   // Match property accesses and method calls (with optional whitespace)
   const chainRegex = /\s*\.\s*(\w+)(\s*\(([^)]*|\([^)]*\))*\))?/g;
   let match;
 
-  while ((match = chainRegex.exec(remaining)) !== null) {
+  while ((match = chainRegex.exec(chainString)) !== null) {
     const name = match[1];
     const isMethod = match[2] !== undefined;
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -169,8 +169,13 @@ export interface ImportMetaMatch {
   /**
    * The parsed chain of property accesses and method calls.
    * @example
-   * - `import.meta.url` → `[{ name: "url", type: "property" }]`
-   * - `import.meta.resolve('./mod')` → `[{ name: "resolve", type: "method", args: ["'./mod'"] }]`
+   * ```ts
+   * // import.meta.url
+   * [{ name: "url", type: "property" }]
+   *
+   * // import.meta.resolve('./mod')
+   * [{ name: "resolve", type: "call", args: ["'./mod'"] }]
+   * ```
    */
   chain: ImportMetaChainItem[];
 }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -139,7 +139,7 @@ interface ImportMetaCallChain {
 /**
  * Represents a member access or method call in an import.meta chain.
  */
-export type ImportMetaChainItem = ImportMetaCallChain | ImportMetaMemberChain;
+type ImportMetaChainItem = ImportMetaCallChain | ImportMetaMemberChain;
 
 /**
  * Represents an import.meta expression in an ECMAScript module.

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -320,10 +320,18 @@ export const DYNAMIC_IMPORT_RE =
  * Regular expression to match import.meta expressions in JavaScript/TypeScript code.
  * Supports multiline property access with whitespace and optional block comments between dots and property names.
  * Captures the full property chain (including nested accesses and calls) while allowing optional block comments between tokens.
- * @example `import.meta.url`, `import.meta.env`, `import.meta.resolve()`, `import . meta . url` with block comments
+ * @example 'import.meta.url', 'import.meta.env', 'import.meta.resolve()', 'import . meta . url' with block comments
  */
 export const IMPORT_META_RE =
   /\bimport\.meta(?<chain>(?:(?:\s*(?:\/\*[\s\S]*?\*\/)?\.\s*(?:\/\*[\s\S]*?\*\/)?[A-Za-z$_][A-Za-z0-9$_]*(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+))/gm;
+
+/**
+ * Regular expression to match property accesses and method calls within import.meta chains.
+ * Supports optional whitespace and block comments between dots and property names.
+ * @example '.url', '.resolve()', '. resolve ( arg )'
+ */
+const IMPORT_META_CHAIN_RE =
+  /\s*(?:\/\*[\s\S]*?\*\/)?\.\s*(?:\/\*[\s\S]*?\*\/)?([A-Za-z$_][A-Za-z0-9$_]*)(\s*\(([^)]*|\([^)]*\))*\))?/g;
 
 const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+(?:[\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
@@ -785,13 +793,9 @@ function _getLocations(code: string, label: string) {
 
 function _parseImportMetaChain(chainString: string): ImportMetaChainItem[] {
   const chain: ImportMetaChainItem[] = [];
-
-  // Match property accesses and method calls (with optional whitespace and block comments)
-  const chainRegex =
-    /\s*(?:\/\*[\s\S]*?\*\/)?\.\s*(?:\/\*[\s\S]*?\*\/)?([A-Za-z$_][A-Za-z0-9$_]*)(\s*\(([^)]*|\([^)]*\))*\))?/g;
   let match;
 
-  while ((match = chainRegex.exec(chainString)) !== null) {
+  while ((match = IMPORT_META_CHAIN_RE.exec(chainString)) !== null) {
     const name = match[1];
     const isMethod = match[2] !== undefined;
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -120,13 +120,13 @@ interface ImportMetaPropertyChain {
   type: "property";
 }
 
-interface ImportMetaMethodChain {
+interface ImportMetaCallChain {
   /**
    * The name of the method.
    */
   name: string;
 
-  type: "method";
+  type: "call";
 
   /**
    * The arguments for method calls.
@@ -139,9 +139,7 @@ interface ImportMetaMethodChain {
 /**
  * Represents a property access or method call in an import.meta chain.
  */
-export type ImportMetaChainItem =
-  | ImportMetaMethodChain
-  | ImportMetaPropertyChain;
+export type ImportMetaChainItem = ImportMetaCallChain | ImportMetaPropertyChain;
 
 /**
  * Represents an import.meta expression in an ECMAScript module.
@@ -828,7 +826,7 @@ function _parseImportMetaChain(code: string): ImportMetaChainItem[] {
 
       chain.push({
         name,
-        type: "method",
+        type: "call",
         args: args.length > 0 ? args : [],
       });
       break;

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -318,12 +318,12 @@ export const DYNAMIC_IMPORT_RE =
 
 /**
  * Regular expression to match import.meta expressions in JavaScript/TypeScript code.
- * Supports multiline property access with whitespace between dots and property names.
- * Captures the entire chain but stops at first method call in post-processing.
- * @example `import.meta.url`, `import.meta.env`, `import.meta.resolve()`
+ * Supports multiline property access with whitespace and optional block comments between dots and property names.
+ * Captures the full property chain (including nested accesses and calls) while allowing optional block comments between tokens.
+ * @example `import.meta.url`, `import.meta.env`, `import.meta.resolve()`, `import . meta . url` with block comments
  */
 export const IMPORT_META_RE =
-  /\bimport\.meta(?<chain>(?:(?:\s*\.\s*\w+(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+))/gm;
+  /\bimport\.meta(?<chain>(?:(?:\s*(?:\/\*[\s\S]*?\*\/)?\.\s*(?:\/\*[\s\S]*?\*\/)?[A-Za-z$_][A-Za-z0-9$_]*(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+))/gm;
 
 const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+(?:[\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
@@ -786,8 +786,9 @@ function _getLocations(code: string, label: string) {
 function _parseImportMetaChain(chainString: string): ImportMetaChainItem[] {
   const chain: ImportMetaChainItem[] = [];
 
-  // Match property accesses and method calls (with optional whitespace)
-  const chainRegex = /\s*\.\s*(\w+)(\s*\(([^)]*|\([^)]*\))*\))?/g;
+  // Match property accesses and method calls (with optional whitespace and block comments)
+  const chainRegex =
+    /\s*(?:\/\*[\s\S]*?\*\/)?\.\s*(?:\/\*[\s\S]*?\*\/)?([A-Za-z$_][A-Za-z0-9$_]*)(\s*\(([^)]*|\([^)]*\))*\))?/g;
   let match;
 
   while ((match = chainRegex.exec(chainString)) !== null) {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -111,13 +111,13 @@ export interface TypeImport extends Omit<ESMImport, "type"> {
   specifier: string;
 }
 
-interface ImportMetaPropertyChain {
+interface ImportMetaMemberChain {
   /**
-   * The name of the property.
+   * The name of the member.
    */
   name: string;
 
-  type: "property";
+  type: "member";
 }
 
 interface ImportMetaCallChain {
@@ -137,9 +137,9 @@ interface ImportMetaCallChain {
 }
 
 /**
- * Represents a property access or method call in an import.meta chain.
+ * Represents a member access or method call in an import.meta chain.
  */
-export type ImportMetaChainItem = ImportMetaCallChain | ImportMetaPropertyChain;
+export type ImportMetaChainItem = ImportMetaCallChain | ImportMetaMemberChain;
 
 /**
  * Represents an import.meta expression in an ECMAScript module.
@@ -167,11 +167,11 @@ export interface ImportMetaMatch {
   end: number;
 
   /**
-   * The parsed chain of property accesses and method calls.
+   * The parsed chain of member accesses and method calls.
    * @example
    * ```ts
    * // import.meta.url
-   * [{ name: "url", type: "property" }]
+   * [{ name: "url", type: "member" }]
    *
    * // import.meta.resolve('./mod')
    * [{ name: "resolve", type: "call", args: ["'./mod'"] }]
@@ -323,16 +323,16 @@ export const DYNAMIC_IMPORT_RE =
 
 /**
  * Regular expression to match import.meta expressions in JavaScript/TypeScript code.
- * Supports multiline property access with whitespace and optional block comments between dots and property names.
- * Captures the full property chain (including nested accesses and calls) while allowing optional block comments between tokens.
+ * Supports multiline member access with whitespace and optional block comments between dots and member names.
+ * Captures the full member chain (including nested accesses and calls) while allowing optional block comments between tokens.
  * @example 'import.meta.url', 'import.meta.env', 'import.meta.resolve()', 'import . meta . url' with block comments
  */
 export const IMPORT_META_RE =
   /\bimport\.meta(?<chain>(?:(?:\s*(?:\/\*[\s\S]*?\*\/)?\.\s*(?:\/\*[\s\S]*?\*\/)?[A-Za-z$_][A-Za-z0-9$_]*(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+))/gm;
 
 /**
- * Regular expression to match property accesses and method calls within import.meta chains.
- * Supports optional whitespace and block comments between dots and property names.
+ * Regular expression to match member accesses and method calls within import.meta chains.
+ * Supports optional whitespace and block comments between dots and member names.
  * @example '.url', '.resolve()', '. resolve ( arg )'
  */
 const IMPORT_META_CHAIN_RE =
@@ -819,7 +819,7 @@ function _parseImportMetaChain(chainString: string): ImportMetaChainItem[] {
     } else {
       chain.push({
         name,
-        type: "property",
+        type: "member",
       });
     }
   }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -111,6 +111,72 @@ export interface TypeImport extends Omit<ESMImport, "type"> {
   specifier: string;
 }
 
+interface ImportMetaPropertyChain {
+  /**
+   * The name of the property.
+   */
+  name: string;
+
+  type: "property";
+}
+
+interface ImportMetaMethodChain {
+  /**
+   * The name of the method.
+   */
+  name: string;
+
+  type: "method";
+
+  /**
+   * The arguments for method calls.
+   *
+   * Empty if no arguments provided.
+   */
+  args: string[];
+}
+
+/**
+ * Represents a property access or method call in an import.meta chain.
+ */
+export type ImportMetaChainItem =
+  | ImportMetaMethodChain
+  | ImportMetaPropertyChain;
+
+/**
+ * Represents an import.meta expression in an ECMAScript module.
+ * Contains position information and parsed chain information for the import.meta occurrence.
+ */
+export interface ImportMetaMatch {
+  /**
+   * Indicates that this is an import.meta expression.
+   */
+  type: "meta";
+
+  /**
+   * The full import.meta expression code snippet as a string.
+   */
+  code: string;
+
+  /**
+   * The starting position (index) of the import.meta expression in the source code.
+   */
+  start: number;
+
+  /**
+   * The end position (index) of the import.meta expression in the source code.
+   */
+  end: number;
+
+  /**
+   * The parsed chain of property accesses and method calls.
+   * @example
+   * - `import.meta.url` → `[{ name: "url", type: "property" }]`
+   * - `import.meta.resolve('./mod')` → `[{ name: "resolve", type: "method", args: ["'./mod'"] }]`
+   */
+  chain: ImportMetaChainItem[];
+}
+
 /**
  * Represents a general structure for ECMAScript module exports.
  */
@@ -251,6 +317,16 @@ export const ESM_STATIC_IMPORT_RE =
  */
 export const DYNAMIC_IMPORT_RE =
   /import\s*\((?<expression>(?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)/gm;
+
+/**
+ * Regular expression to match import.meta expressions in JavaScript/TypeScript code.
+ * Supports multiline property access with whitespace between dots and property names.
+ * Captures the entire chain but stops at first method call in post-processing.
+ * @example `import.meta.url`, `import.meta.env`, `import.meta.resolve()`
+ */
+export const IMPORT_META_RE =
+  /\bimport\.meta(?:(?:\s*\.\s*\w+(?:\s*\((?:[^()]+|\([^)]*\))*\))?)+)/gm;
+
 const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+(?:[\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
 
@@ -317,6 +393,46 @@ export function findTypeImports(code: string): TypeImport[] {
       (match) => /[^A-Za-z]type\s/.test(match.imports),
     ),
   ];
+}
+
+/**
+ * Finds all import.meta expressions within the given code string.
+ * @param {string} code - The source code to search for import.meta expressions.
+ * @returns {ImportMetaMatch[]} An array of {@link ImportMetaMatch} objects representing each import.meta expression found.
+ */
+export function findImportMeta(code: string): ImportMetaMatch[] {
+  const matches = matchAll(IMPORT_META_RE, code, { type: "meta" });
+  const filtered = _filterStatement(_tryGetLocations(code, "import"), matches);
+
+  // Parse each match to extract chain information and adjust match boundaries
+  return filtered.map((match) => {
+    const originalCode = match.code;
+    const chain = _parseImportMetaChain(originalCode);
+
+    // Find where the first method call ends using regex (with optional whitespace)
+    const firstMethodPattern =
+      /^import\.meta(?:\s*\.\s*\w+)*?(\s*\.\s*\w+\s*\([^)]*(?:\([^)]*\)[^)]*)*\))/;
+    const methodMatch = originalCode.match(firstMethodPattern);
+
+    if (methodMatch) {
+      // Cut the code at the end of the first method call
+      const methodEndPos = methodMatch[0].length;
+      const adjustedCode = originalCode.slice(0, methodEndPos);
+      const adjustedEnd = match.start + methodEndPos;
+
+      return {
+        ...match,
+        code: adjustedCode,
+        end: adjustedEnd,
+        chain,
+      };
+    }
+
+    return {
+      ...match,
+      chain,
+    };
+  });
 }
 
 /**
@@ -687,4 +803,42 @@ function _getLocations(code: string, label: string) {
     }
   }
   return locations;
+}
+
+function _parseImportMetaChain(code: string): ImportMetaChainItem[] {
+  const chain: ImportMetaChainItem[] = [];
+
+  // Remove "import.meta" prefix and parse the rest
+  const remaining = code.replace(/^import\.meta/, "");
+
+  // Match property accesses and method calls (with optional whitespace)
+  const chainRegex = /\s*\.\s*(\w+)(\s*\(([^)]*|\([^)]*\))*\))?/g;
+  let match;
+
+  while ((match = chainRegex.exec(remaining)) !== null) {
+    const name = match[1];
+    const isMethod = match[2] !== undefined;
+
+    if (isMethod) {
+      const argsString = match[3] || "";
+      const args = argsString
+        .split(",")
+        .map((arg) => arg.trim())
+        .filter((arg) => arg.length > 0);
+
+      chain.push({
+        name,
+        type: "method",
+        args: args.length > 0 ? args : [],
+      });
+      break;
+    } else {
+      chain.push({
+        name,
+        type: "property",
+      });
+    }
+  }
+
+  return chain;
 }

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -314,7 +314,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.resolve()",
       start: 0,
       end: 21,
-      chain: [{ name: "resolve", type: "method", args: [] }],
+      chain: [{ name: "resolve", type: "call", args: [] }],
     },
   ],
   "import.meta.resolve('./module')": [
@@ -323,7 +323,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.resolve('./module')",
       start: 0,
       end: 31,
-      chain: [{ name: "resolve", type: "method", args: ["'./module'"] }],
+      chain: [{ name: "resolve", type: "call", args: ["'./module'"] }],
     },
   ],
   'import.meta.resolve("./module")': [
@@ -332,7 +332,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: 'import.meta.resolve("./module")',
       start: 0,
       end: 31,
-      chain: [{ name: "resolve", type: "method", args: ['"./module"'] }],
+      chain: [{ name: "resolve", type: "call", args: ['"./module"'] }],
     },
   ],
 
@@ -345,7 +345,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       end: 24,
       chain: [
         { name: "foo", type: "property" },
-        { name: "method", type: "method", args: [] },
+        { name: "method", type: "call", args: [] },
       ],
     },
   ],
@@ -357,7 +357,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       end: 31,
       chain: [
         { name: "env", type: "property" },
-        { name: "getValue", type: "method", args: ["'key'"] },
+        { name: "getValue", type: "call", args: ["'key'"] },
       ],
     },
   ],
@@ -376,7 +376,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.resolve(url)",
       start: 29,
       end: 53,
-      chain: [{ name: "resolve", type: "method", args: ["url"] }],
+      chain: [{ name: "resolve", type: "call", args: ["url"] }],
     },
   ],
 
@@ -397,7 +397,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.resolve('./mod')",
       start: 0,
       end: 28,
-      chain: [{ name: "resolve", type: "method", args: ["'./mod'"] }],
+      chain: [{ name: "resolve", type: "call", args: ["'./mod'"] }],
     },
   ],
 
@@ -407,7 +407,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.resolve()",
       start: 0,
       end: 21,
-      chain: [{ name: "resolve", type: "method", args: [] }],
+      chain: [{ name: "resolve", type: "call", args: [] }],
     },
   ],
 };
@@ -463,7 +463,7 @@ importMetaTests[
     chain: [
       {
         name: "resolve",
-        type: "method",
+        type: "call",
         args: ["'./module'", "{ conditions: ['import'] }"],
       },
     ],

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import type { ImportMetaMatch } from "../src";
+import type { ImportMetaExpression } from "../src";
 import {
   findDynamicImports,
   findStaticImports,
@@ -260,7 +260,7 @@ const TypeTests = {
   },
 };
 
-const importMetaTests: Record<string, ImportMetaMatch[]> = {
+const importMetaTests: Record<string, ImportMetaExpression[]> = {
   // Basic member expressions
   "const baseUrl = import.meta.url": [
     {

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
+
+import type { ImportMetaMatch } from "../src";
 import {
   findDynamicImports,
   findStaticImports,
+  findImportMeta,
   parseStaticImport,
   findTypeImports,
   parseTypeImport,
@@ -257,6 +260,216 @@ const TypeTests = {
   },
 };
 
+const importMetaTests: Record<string, ImportMetaMatch[]> = {
+  // 1 depth property access
+  "import.meta.url": [
+    {
+      type: "meta",
+      code: "import.meta.url",
+      start: 0,
+      end: 15,
+      chain: [{ name: "url", type: "property" }],
+    },
+  ],
+  "import.meta.env": [
+    {
+      type: "meta",
+      code: "import.meta.env",
+      start: 0,
+      end: 15,
+      chain: [{ name: "env", type: "property" }],
+    },
+  ],
+
+  // 2+ depth property access
+  "import.meta.env.NODE_ENV": [
+    {
+      type: "meta",
+      code: "import.meta.env.NODE_ENV",
+      start: 0,
+      end: 24,
+      chain: [
+        { name: "env", type: "property" },
+        { name: "NODE_ENV", type: "property" },
+      ],
+    },
+  ],
+  "const version = import.meta.env.VITE_VERSION || 'dev'": [
+    {
+      type: "meta",
+      code: "import.meta.env.VITE_VERSION",
+      start: 16,
+      end: 44,
+      chain: [
+        { name: "env", type: "property" },
+        { name: "VITE_VERSION", type: "property" },
+      ],
+    },
+  ],
+
+  // 1 depth method call
+  "import.meta.resolve()": [
+    {
+      type: "meta",
+      code: "import.meta.resolve()",
+      start: 0,
+      end: 21,
+      chain: [{ name: "resolve", type: "method", args: [] }],
+    },
+  ],
+  "import.meta.resolve('./module')": [
+    {
+      type: "meta",
+      code: "import.meta.resolve('./module')",
+      start: 0,
+      end: 31,
+      chain: [{ name: "resolve", type: "method", args: ["'./module'"] }],
+    },
+  ],
+  'import.meta.resolve("./module")': [
+    {
+      type: "meta",
+      code: 'import.meta.resolve("./module")',
+      start: 0,
+      end: 31,
+      chain: [{ name: "resolve", type: "method", args: ['"./module"'] }],
+    },
+  ],
+
+  // 2+ depth method call
+  "import.meta.foo.method()": [
+    {
+      type: "meta",
+      code: "import.meta.foo.method()",
+      start: 0,
+      end: 24,
+      chain: [
+        { name: "foo", type: "property" },
+        { name: "method", type: "method", args: [] },
+      ],
+    },
+  ],
+  "import.meta.env.getValue('key')": [
+    {
+      type: "meta",
+      code: "import.meta.env.getValue('key')",
+      start: 0,
+      end: 31,
+      chain: [
+        { name: "env", type: "property" },
+        { name: "getValue", type: "method", args: ["'key'"] },
+      ],
+    },
+  ],
+
+  // multiple statement
+  "const url = import.meta.url; import.meta.resolve(url)": [
+    {
+      type: "meta",
+      code: "import.meta.url",
+      start: 12,
+      end: 27,
+      chain: [{ name: "url", type: "property" }],
+    },
+    {
+      type: "meta",
+      code: "import.meta.resolve(url)",
+      start: 29,
+      end: 53,
+      chain: [{ name: "resolve", type: "method", args: ["url"] }],
+    },
+  ],
+
+  // negative cases
+  "// import.meta": [],
+  "/* import.meta */": [],
+  '"import.meta.url"': [],
+
+  // TODO: determine whether to support chained method call
+  // This is highly inappropriate as a user extension for ImportMeta and would encourage unnecessarily complex extensions,
+  // so it should not be supported.
+  //
+  // However, when encountering such statements, I haven't decided whether to
+  // "capture up to the first method call" (current behavior) or "skip completely."
+  "import.meta.resolve('./mod').then(console.log)": [
+    {
+      type: "meta",
+      code: "import.meta.resolve('./mod')",
+      start: 0,
+      end: 28,
+      chain: [{ name: "resolve", type: "method", args: ["'./mod'"] }],
+    },
+  ],
+
+  "import.meta.resolve().catch().finally()": [
+    {
+      type: "meta",
+      code: "import.meta.resolve()",
+      start: 0,
+      end: 21,
+      chain: [{ name: "resolve", type: "method", args: [] }],
+    },
+  ],
+};
+
+// multiline property access
+importMetaTests[
+  `import.meta
+  .url`
+] = [
+  {
+    type: "meta",
+    code: `import.meta
+  .url`,
+    start: 0,
+    end: 18,
+    chain: [{ name: "url", type: "property" }],
+  },
+];
+importMetaTests[
+  `import.meta
+    .env
+    .NODE_ENV`
+] = [
+  {
+    type: "meta",
+    code: `import.meta
+    .env
+    .NODE_ENV`,
+    start: 0,
+    end: 34,
+    chain: [
+      { name: "env", type: "property" },
+      { name: "NODE_ENV", type: "property" },
+    ],
+  },
+];
+
+// multiline args
+importMetaTests[
+  `import.meta.resolve(
+  './module',
+  { conditions: ['import'] }
+)`
+] = [
+  {
+    type: "meta",
+    code: `import.meta.resolve(
+  './module',
+  { conditions: ['import'] }
+)`,
+    start: 0,
+    end: 65,
+    chain: [
+      {
+        name: "resolve",
+        type: "method",
+        args: ["'./module'", "{ conditions: ['import'] }"],
+      },
+    ],
+  },
+];
+
 describe("findStaticImports", () => {
   for (const [input, _results] of Object.entries(staticTests)) {
     it(input.replace(/\n/g, String.raw`\n`), () => {
@@ -321,6 +534,23 @@ describe("findTypeImports", () => {
         if (test.namespacedImport) {
           expect(parsed.namespacedImport).to.eql(test.namespacedImport);
         }
+      }
+    });
+  }
+});
+
+describe("findImportMeta", () => {
+  for (const [input, expected] of Object.entries(importMetaTests)) {
+    it(input.replace(/\n/g, String.raw`\n`), () => {
+      const matches = findImportMeta(input);
+      expect(matches.length).toEqual(expected.length);
+      for (const [index, test] of expected.entries()) {
+        const match = matches[index];
+        expect(match.type).to.equal("meta");
+        expect(match.code).to.equal(test.code);
+        expect(match.start).to.equal(test.start);
+        expect(match.end).to.equal(test.end);
+        expect(match.chain).to.eql(test.chain);
       }
     });
   }

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -362,7 +362,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
     },
   ],
 
-  // multiple statement
+  // multiple statements
   "const url = import.meta.url; import.meta.resolve(url)": [
     {
       type: "meta",
@@ -380,52 +380,27 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
     },
   ],
 
+  // chain calls
+  "import.meta.resolve('./mod').then(console.log)": [
+    {
+      type: "meta",
+      code: "import.meta.resolve('./mod').then(console.log)",
+      start: 0,
+      end: 46,
+      chain: [
+        { name: "resolve", type: "call", args: ["'./mod'"] },
+        { name: "then", type: "call", args: ["console.log"] },
+      ],
+    },
+  ],
+
   // negative cases
   "// import.meta": [],
   "/* import.meta */": [],
   '"import.meta.url"': [],
-
-  // TODO: determine whether to support chained method call
-  // This is highly inappropriate as a user extension for ImportMeta and would encourage unnecessarily complex extensions,
-  // so it should not be supported.
-  //
-  // However, when encountering such statements, I haven't decided whether to
-  // "capture up to the first method call" (current behavior) or "skip completely."
-  "import.meta.resolve('./mod').then(console.log)": [
-    {
-      type: "meta",
-      code: "import.meta.resolve('./mod')",
-      start: 0,
-      end: 28,
-      chain: [{ name: "resolve", type: "call", args: ["'./mod'"] }],
-    },
-  ],
-
-  "import.meta.resolve().catch().finally()": [
-    {
-      type: "meta",
-      code: "import.meta.resolve()",
-      start: 0,
-      end: 21,
-      chain: [{ name: "resolve", type: "call", args: [] }],
-    },
-  ],
 };
 
-// multiline property access
-importMetaTests[
-  `import.meta
-  .url`
-] = [
-  {
-    type: "meta",
-    code: `import.meta
-  .url`,
-    start: 0,
-    end: 18,
-    chain: [{ name: "url", type: "property" }],
-  },
-];
+// multiline chain
 importMetaTests[
   `import.meta
     .env
@@ -441,6 +416,24 @@ importMetaTests[
     chain: [
       { name: "env", type: "property" },
       { name: "NODE_ENV", type: "property" },
+    ],
+  },
+];
+importMetaTests[
+  `import.meta
+    .resolve()
+    .then(console.log)`
+] = [
+  {
+    type: "meta",
+    code: `import.meta
+    .resolve()
+    .then(console.log)`,
+    start: 0,
+    end: 49,
+    chain: [
+      { name: "resolve", type: "call", args: [] },
+      { name: "then", type: "call", args: ["console.log"] },
     ],
   },
 ];

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -398,6 +398,50 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
   "// import.meta": [],
   "/* import.meta */": [],
   '"import.meta.url"': [],
+  // Block comments between tokens
+  "import.meta/* comment */.url": [
+    {
+      type: "meta",
+      code: "import.meta/* comment */.url",
+      start: 0,
+      end: 28,
+      chain: [{ name: "url", type: "property" }],
+    },
+  ],
+  "import.meta./* comment */env.NODE_ENV": [
+    {
+      type: "meta",
+      code: "import.meta./* comment */env.NODE_ENV",
+      start: 0,
+      end: 37,
+      chain: [
+        { name: "env", type: "property" },
+        { name: "NODE_ENV", type: "property" },
+      ],
+    },
+  ],
+  // $ in identifier names
+  "import.meta.$store": [
+    {
+      type: "meta",
+      code: "import.meta.$store",
+      start: 0,
+      end: 18,
+      chain: [{ name: "$store", type: "property" }],
+    },
+  ],
+  "import.meta.env.$NODE_ENV": [
+    {
+      type: "meta",
+      code: "import.meta.env.$NODE_ENV",
+      start: 0,
+      end: 25,
+      chain: [
+        { name: "env", type: "property" },
+        { name: "$NODE_ENV", type: "property" },
+      ],
+    },
+  ],
 };
 
 // multiline chain

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -261,153 +261,66 @@ const TypeTests = {
 };
 
 const importMetaTests: Record<string, ImportMetaMatch[]> = {
-  // 1 depth property access
-  "import.meta.url": [
+  // Basic member expressions
+  "const baseUrl = import.meta.url": [
     {
       type: "meta",
       code: "import.meta.url",
-      start: 0,
-      end: 15,
+      start: 16,
+      end: 31,
       chain: [{ name: "url", type: "property" }],
     },
   ],
-  "import.meta.env": [
-    {
-      type: "meta",
-      code: "import.meta.env",
-      start: 0,
-      end: 15,
-      chain: [{ name: "env", type: "property" }],
-    },
-  ],
 
-  // 2+ depth property access
-  "import.meta.env.NODE_ENV": [
+  "export const IS_DEV = import.meta.env.NODE_ENV === 'development'": [
     {
       type: "meta",
       code: "import.meta.env.NODE_ENV",
-      start: 0,
-      end: 24,
+      start: 22,
+      end: 46,
       chain: [
         { name: "env", type: "property" },
         { name: "NODE_ENV", type: "property" },
       ],
     },
   ],
-  "const version = import.meta.env.VITE_VERSION || 'dev'": [
+  "import.meta.$dummy": [
     {
       type: "meta",
-      code: "import.meta.env.VITE_VERSION",
-      start: 16,
-      end: 44,
-      chain: [
-        { name: "env", type: "property" },
-        { name: "VITE_VERSION", type: "property" },
-      ],
+      code: "import.meta.$dummy",
+      start: 0,
+      end: 18,
+      chain: [{ name: "$dummy", type: "property" }],
     },
   ],
 
-  // 1 depth method call
-  "import.meta.resolve()": [
+  // Basic call expressions
+  "const resolved = import.meta.resolve('./config')": [
     {
       type: "meta",
-      code: "import.meta.resolve()",
-      start: 0,
-      end: 21,
-      chain: [{ name: "resolve", type: "call", args: [] }],
+      code: "import.meta.resolve('./config')",
+      start: 17,
+      end: 48,
+      chain: [{ name: "resolve", type: "call", args: ["'./config'"] }],
     },
   ],
-  "import.meta.resolve('./module')": [
+  "import.meta.glob('./pages/**/*.vue', { eager: true })": [
     {
       type: "meta",
-      code: "import.meta.resolve('./module')",
+      code: "import.meta.glob('./pages/**/*.vue', { eager: true })",
       start: 0,
-      end: 31,
-      chain: [{ name: "resolve", type: "call", args: ["'./module'"] }],
-    },
-  ],
-  'import.meta.resolve("./module")': [
-    {
-      type: "meta",
-      code: 'import.meta.resolve("./module")',
-      start: 0,
-      end: 31,
-      chain: [{ name: "resolve", type: "call", args: ['"./module"'] }],
-    },
-  ],
-
-  // 2+ depth method call
-  "import.meta.foo.method()": [
-    {
-      type: "meta",
-      code: "import.meta.foo.method()",
-      start: 0,
-      end: 24,
-      chain: [
-        { name: "foo", type: "property" },
-        { name: "method", type: "call", args: [] },
-      ],
-    },
-  ],
-  "import.meta.env.getValue('key')": [
-    {
-      type: "meta",
-      code: "import.meta.env.getValue('key')",
-      start: 0,
-      end: 31,
-      chain: [
-        { name: "env", type: "property" },
-        { name: "getValue", type: "call", args: ["'key'"] },
-      ],
-    },
-  ],
-
-  // multiple statements
-  "const url = import.meta.url; import.meta.resolve(url)": [
-    {
-      type: "meta",
-      code: "import.meta.url",
-      start: 12,
-      end: 27,
-      chain: [{ name: "url", type: "property" }],
-    },
-    {
-      type: "meta",
-      code: "import.meta.resolve(url)",
-      start: 29,
       end: 53,
-      chain: [{ name: "resolve", type: "call", args: ["url"] }],
-    },
-  ],
-
-  // chain calls
-  "import.meta.resolve('./mod').then(console.log)": [
-    {
-      type: "meta",
-      code: "import.meta.resolve('./mod').then(console.log)",
-      start: 0,
-      end: 46,
       chain: [
-        { name: "resolve", type: "call", args: ["'./mod'"] },
-        { name: "then", type: "call", args: ["console.log"] },
+        {
+          name: "glob",
+          type: "call",
+          args: ["'./pages/**/*.vue'", "{ eager: true }"],
+        },
       ],
     },
   ],
 
-  // negative cases
-  "// import.meta": [],
-  "/* import.meta */": [],
-  '"import.meta.url"': [],
   // Block comments between tokens
-  "import.meta/* comment */.url": [
-    {
-      type: "meta",
-      code: "import.meta/* comment */.url",
-      start: 0,
-      end: 28,
-      chain: [{ name: "url", type: "property" }],
-    },
-  ],
   "import.meta./* comment */env.NODE_ENV": [
     {
       type: "meta",
@@ -420,28 +333,11 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       ],
     },
   ],
-  // $ in identifier names
-  "import.meta.$store": [
-    {
-      type: "meta",
-      code: "import.meta.$store",
-      start: 0,
-      end: 18,
-      chain: [{ name: "$store", type: "property" }],
-    },
-  ],
-  "import.meta.env.$NODE_ENV": [
-    {
-      type: "meta",
-      code: "import.meta.env.$NODE_ENV",
-      start: 0,
-      end: 25,
-      chain: [
-        { name: "env", type: "property" },
-        { name: "$NODE_ENV", type: "property" },
-      ],
-    },
-  ],
+
+  // negative cases
+  "// import.meta.url": [],
+  "/* import.meta.url */": [],
+  '"import.meta.url"': [],
 };
 
 // multiline chain

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -268,7 +268,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.url",
       start: 16,
       end: 31,
-      chain: [{ name: "url", type: "property" }],
+      chain: [{ name: "url", type: "member" }],
     },
   ],
 
@@ -279,8 +279,8 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       start: 22,
       end: 46,
       chain: [
-        { name: "env", type: "property" },
-        { name: "NODE_ENV", type: "property" },
+        { name: "env", type: "member" },
+        { name: "NODE_ENV", type: "member" },
       ],
     },
   ],
@@ -290,7 +290,7 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       code: "import.meta.$dummy",
       start: 0,
       end: 18,
-      chain: [{ name: "$dummy", type: "property" }],
+      chain: [{ name: "$dummy", type: "member" }],
     },
   ],
 
@@ -328,8 +328,8 @@ const importMetaTests: Record<string, ImportMetaMatch[]> = {
       start: 0,
       end: 37,
       chain: [
-        { name: "env", type: "property" },
-        { name: "NODE_ENV", type: "property" },
+        { name: "env", type: "member" },
+        { name: "NODE_ENV", type: "member" },
       ],
     },
   ],
@@ -354,8 +354,8 @@ importMetaTests[
     start: 0,
     end: 34,
     chain: [
-      { name: "env", type: "property" },
-      { name: "NODE_ENV", type: "property" },
+      { name: "env", type: "member" },
+      { name: "NODE_ENV", type: "member" },
     ],
   },
 ];


### PR DESCRIPTION
- related: https://github.com/unjs/mlly/issues/323


Known limitation:
Passing a JavaScript arrow function as an argument to an import.meta member method is not parsed correctly in some edge cases;
I'm ignoring this for now since import.meta doesn’t currently define such extensions

```ts
import.meta.some.method((arg) => doSomething(arg)); // We cannot handle this correctly
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds a public API to detect and parse import.meta usage, including chained properties and method calls (multiline supported), returning structured results with positions and parsed chains.

- Tests
  - Adds comprehensive tests covering single- and multi-depth properties/methods, mixed and chained calls, multiline forms, and negative cases; validates returned snippets, positions, and parsed chain structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->